### PR TITLE
Copy files workflow

### DIFF
--- a/.github/workflows/copy-files.yml
+++ b/.github/workflows/copy-files.yml
@@ -1,0 +1,26 @@
+on: 
+  push:
+    paths:
+      - 'website_material/**'
+
+jobs:
+  copy-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          respositories: "test-website"
+      - uses: lubu12/copy-files-to-repository@v1
+        env:
+          API_TOKEN_GITHUB: ${{ steps.app-token.outputs.token }}
+        with:
+          source-files: 'website_material/'
+          destination-username: ${{ github.repository_owner }}
+          destination-repository: 'test-website'
+          destination-branch: 'slug'
+          destination-directory: 'src/pages/models/slug'
+          commit-email: 'tim.white@sydney.edu.au'

--- a/.github/workflows/copy-files.yml
+++ b/.github/workflows/copy-files.yml
@@ -1,5 +1,7 @@
 on: 
   push:
+    branches:
+      - 'main'
     paths:
       - 'website_material/**'
 
@@ -11,16 +13,17 @@ jobs:
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
-          private-key: ${{ secrets.PRIVATE_KEY }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          respositories: "test-website"
+          repositories: 'website'
+
       - uses: lubu12/copy-files-to-repository@v1
         env:
           API_TOKEN_GITHUB: ${{ steps.app-token.outputs.token }}
         with:
           source-files: 'website_material/'
           destination-username: ${{ github.repository_owner }}
-          destination-repository: 'test-website'
-          destination-branch: 'slug'
-          destination-directory: 'src/pages/models/slug'
-          commit-email: 'tim.white@sydney.edu.au'
+          destination-repository: 'website'
+          destination-branch: ${{ github.repository.name }}
+          destination-directory: 'src/pages/models/${{ github.repository.name }}'
+          commit-email: ''


### PR DESCRIPTION
This workflow should be able to copy files from repositories created with this template to the M@TE website repository, provided a Github App has been set up correctly for the organization.